### PR TITLE
Add Build and Publish scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vscode
+export
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+SHELL = /usr/bin/env bash -xe
+
+PWD := $(shell pwd)
+
+build:
+	@rm -rf export
+	@mkdir export
+	@zip -yr export/layer.zip bootstrap bin lib libexec share
+
+publish:
+	@$(PWD)/publish.sh
+
+.PHONY: \
+	build
+	publish

--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ Bash behaves in ways unlike other programming languages. As such, there are some
 
     `AWS_LAMBDA_TRACE_ID` - The sampling decision, trace ID, and parent segment ID of AWS XRay
 
+### Building
+
+To build a layer, simply run `make build`. This will create a zip archive of the layer in the `export/` directory.
+
+### Publishing
+
+To publish the layer to the public, simply run `make publish`. This will create a new version of the layer from the `export/layer.zip` file (create from the Build step) and give it a global read permission.
+
+### Adding New Executables
+
+Some executables are able to run by themselves and some require additional dependencies that are present on the server. It's hard to cover here case here, but if the executable run by itself it can easily be added. If it has dependencies, you must explore what those dependencies are and how to add them to the layer as well.
+
+You can either add the executable from an Amazon Linux AMI or from the [lambci/lambda-build:python-36](https://github.com/lambci/docker-lambda) Docker image.
+
+_Disclaimer: I usually don't add in executables from pull requests for security reasons. If you would like to see an executable in this layer make an issue and I'll try to add it._
+
 ### Included Executables
 
 - `$ aws`

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+
+# AWS Regions
+REGIONS=(
+    "us-west-1"
+    "us-west-2"
+    "us-east-1"
+    "us-east-2"
+    "ap-south-1"
+    "ap-northeast-1"
+    "ap-northeast-2"
+    "ap-southeast-1"
+    "ap-southeast-2"
+    "ca-central-1"
+    "eu-central-1"
+    "eu-north-1"
+    "eu-west-1"
+    "eu-west-2"
+    "eu-west-3"
+    "sa-east-1"
+)
+
+for region in ${REGIONS[@]}; do
+    echo "Publishing layer to $region..."
+
+    LAYER_ARN=$(aws lambda publish-layer-version --region $region --layer-name bash --description "Bash in AWS Lambda [https://github.com/gkrizek/bash-lambda-layer]" --compatible-runtimes provided --license MIT --zip-file fileb://export/layer.zip | jq -r .LayerVersionArn)
+    POLICY=$(aws lambda add-layer-version-permission --region $region --layer-name bash --version-number $(echo -n $LAYER_ARN | tail -c 1) --statement-id bash-public --action lambda:GetLayerVersion --principal \*)
+    
+    echo $LAYER_ARN
+    echo "$region complete"
+    echo ""
+done
+
+echo "Successfully published to all regions"


### PR DESCRIPTION
Adds a `Makefile` with two targets:

- build
- publish

`build` will build the layer zip file and `publish` will create a new layer version with that zip file and give it a public read permission.

This also add documentation to the README about building layers and executables.

Closes #10 
